### PR TITLE
feat: 반응형 모바일 네비게이션 구현

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,50 +1,51 @@
 <script setup>
 import './assets/index.css';
-import Navigation from './components/Navigation/Navigation.vue';
+import Navigation from './components/Navigation.vue';
 import HedaerBox from './components/Header.vue';
 import FooterBox from './components/Footer.vue';
 import ThemeButton from './components/Button/ThemeButton.vue';
 import DefaultLayout from './layout/DefaultLayout.vue';
 import ContentsLayout from './layout/ContentsLayout.vue';
 import { useChangeTheme } from './stores/theme.js';
-import { useResponsive } from './stores/windowSize.js'
-import {useOnMobileNav} from './stores/mobileNav.js'
+import { useResponsive } from './stores/windowSize.js';
+import { useOnMobileNav } from './stores/isMobileNav.js';
 import { onMounted } from 'vue';
 
 const themeStore = useChangeTheme();
 const responsive = useResponsive();
 const nav = useOnMobileNav();
 
-window.addEventListener('resize',() => {
-  if(window.innerWidth < 1024) {
-    responsive.setMobile()
-  } else {
-    responsive.setPc()
-  }
-})
-onMounted(()=>{
-  window.innerWidth < 1024 ?  responsive.setMobile() : responsive.setPc();
-})
+onMounted(() => {
+  window.addEventListener('resize', () => {
+    if (window.innerWidth < 1024) {
+      responsive.setMobile();
+    } else {
+      responsive.setPc();
+      if (nav.isMobileNav) {
+        nav.setNav();
+      }
+    }
+  });
+});
 </script>
 
 <template>
   <main :class="themeStore.isDark ? 'dark' : 'light'">
-     <section>
+    <section>
       <HedaerBox />
       <DefaultLayout>
-        <Navigation v-if="responsive.isMobile ? nav.isMobileNav : !nav.isMobileNav" />
+        <Navigation />
         <ContentsLayout>
           <RouterView />
         </ContentsLayout>
       </DefaultLayout>
       <ThemeButton />
       <FooterBox />
-     </section>
+    </section>
   </main>
 </template>
 
 <style scoped>
-
 section {
   @apply bg-white text-black dark:bg-[#2f2f2f] dark:text-white;
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,7 @@ const responsive = useResponsive();
 const nav = useOnMobileNav();
 
 window.addEventListener('resize', () => {
-  if (window.innerWidth < 1024) {
+  if (window.innerWidth <= 1024) {
     responsive.setMobile();
   } else {
     responsive.setPc();
@@ -24,6 +24,7 @@ window.addEventListener('resize', () => {
     }
   }
 });
+window.innerWidth <= 1024 ? responsive.setMobile() : responsive.setPc();
 </script>
 
 <template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,23 +9,20 @@ import ContentsLayout from './layout/ContentsLayout.vue';
 import { useChangeTheme } from './stores/theme.js';
 import { useResponsive } from './stores/windowSize.js';
 import { useOnMobileNav } from './stores/isMobileNav.js';
-import { onMounted } from 'vue';
 
 const themeStore = useChangeTheme();
 const responsive = useResponsive();
 const nav = useOnMobileNav();
 
-onMounted(() => {
-  window.addEventListener('resize', () => {
-    if (window.innerWidth < 1024) {
-      responsive.setMobile();
-    } else {
-      responsive.setPc();
-      if (nav.isMobileNav) {
-        nav.setNav();
-      }
+window.addEventListener('resize', () => {
+  if (window.innerWidth < 1024) {
+    responsive.setMobile();
+  } else {
+    responsive.setPc();
+    if (nav.isMobileNav) {
+      nav.setNav();
     }
-  });
+  }
 });
 </script>
 

--- a/src/components/Button/MobileNavButton.vue
+++ b/src/components/Button/MobileNavButton.vue
@@ -1,0 +1,119 @@
+<script setup>
+import { useOnMobileNav } from '@/stores/isMobileNav.js';
+const nav = useOnMobileNav();
+
+const handleSetNav = () => {
+  nav.setNav();
+};
+</script>
+<template>
+  <div class="btn-wrapper" @click="handleSetNav">
+    <div class="ham" :class="nav.isMobileNav ? 'active' : ''">
+      <span class="bar"></span>
+    </div>
+  </div>
+</template>
+<style scoped>
+.btn-wrapper {
+  display: none;
+  width: 25px;
+  height: 25px;
+  position: relative;
+  z-index: 30;
+}
+.ham {
+  position: absolute;
+  width: 25px;
+  height: 25px;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  border-radius: 3px;
+}
+
+.ham .bar {
+  display: block;
+  width: 0px;
+  height: 3px;
+  border-radius: 3px;
+  background-color: #000;
+  margin-top: 11px;
+  position: relative;
+  @apply dark:bg-white;
+}
+.ham .bar:before {
+  content: '';
+  width: 25px;
+  height: 3px;
+  border-radius: 3px;
+  background-color: #000;
+  position: absolute;
+  left: 2px;
+  bottom: 0;
+  transition: transform 0.3s;
+  @apply dark:bg-white;
+}
+.ham .bar:after {
+  content: '';
+  width: 25px;
+  height: 3px;
+  border-radius: 3px;
+  background-color: #000;
+  position: absolute;
+  left: 2px;
+  bottom: 0;
+  transition: transform 0.3s;
+  @apply dark:bg-white;
+}
+
+.ham.active span:before {
+  transform: rotate(45deg);
+  transition: transform 0.3s 0.5s;
+}
+
+.ham.active span:after {
+  transform: rotate(-45deg);
+  transition: transform 0.3s 0.5s;
+}
+
+.ham:before {
+  content: '';
+  width: 25px;
+  height: 3px;
+  background-color: #000;
+  border-radius: 3px;
+  position: absolute;
+  right: -2px;
+  top: 0px;
+  transition: width 0.3s;
+  @apply dark:bg-white;
+}
+.ham:after {
+  content: '';
+  width: 25px;
+  height: 3px;
+  background-color: #000;
+  border-radius: 3px;
+  position: absolute;
+  bottom: 0px;
+  left: 2px;
+  transition: width 0.3s;
+  @apply dark:bg-white;
+}
+
+.ham.active:before {
+  width: 0;
+  right: -2px;
+  top: 0px;
+}
+.ham.active:after {
+  width: 0;
+  left: 0px;
+  bottom: 0px;
+}
+@media (max-width: 1024px) {
+  .btn-wrapper {
+    display: block;
+  }
+}
+</style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,0 +1,70 @@
+<script setup>
+import MobileNavButton from './Button/MobileNavButton.vue';
+import whiteLogo from '@/assets/images/logo-white.png';
+import blackLogo from '@/assets/images/logo-black.png';
+import { useChangeTheme } from '@/stores/theme';
+
+const theme = useChangeTheme();
+</script>
+
+<template>
+  <header class="border-b-[1px] border-black dark:border-white">
+    <router-link to="/">
+      <img
+        :src="theme.isDark ? whiteLogo : blackLogo"
+        alt="logo"
+        class="img-logo"
+      />
+    </router-link>
+    <h1 class="text-black dark:text-white">
+      Why we use <span class="text-green-700 dark:text-vueGreen">Vue.js</span>
+    </h1>
+    <MobileNavButton />
+  </header>
+</template>
+
+<style scoped>
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  width: 100%;
+}
+
+.img-logo {
+  width: 4rem;
+  height: 4rem;
+}
+
+h1 {
+  flex: 1;
+  text-align: center;
+  font-weight: 700;
+  font-size: 40px;
+  text-shadow: rgba(0, 0, 0, 0.25) 5px 5px 10px;
+  justify-self: center;
+}
+
+a {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+a span {
+  width: 100%;
+  text-align: center;
+  font-size: smaller;
+}
+
+#pdf-id {
+  font-weight: 500;
+  font-size: 15px;
+}
+
+@media (max-width: 1024px) {
+  h1 {
+    display: none;
+  }
+}
+</style>

--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -1,0 +1,82 @@
+<script setup>
+import { useOnMobileNav } from '@/stores/isMobileNav.js';
+import { useResponsive } from '@/stores/windowSize';
+
+const nav = useOnMobileNav();
+const responsive = useResponsive();
+const navList = [
+  { id: 1, link: '/', title: 'Vanilla Javascript vs Vue.js' },
+  { id: 2, link: '/webpage-and-frontend', title: '프론트개발의 변화' },
+  { id: 3, link: '/vue', title: 'Vue.js에 대하여' },
+  { id: 4, link: '/conclusion', title: '결론' },
+  { id: 5, link: '/others', title: '기타사항' },
+  { id: 6, link: '/reference', title: '참고문서' },
+];
+const handleSetNav = () => {
+  responsive.isMobile && nav.setNav();
+};
+</script>
+<template>
+  <nav
+    :class="{ active: nav.isMobileNav }"
+    class="border-r-[1px] border-black dark:border-white"
+  >
+    <ul>
+      <li @click="handleSetNav" v-for="nav in navList" :key="nav.id">
+        <router-link :to="nav.link">{{ nav.title }}</router-link>
+      </li>
+    </ul>
+  </nav>
+</template>
+
+<style scoped>
+nav {
+  width: fit-content;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+ul {
+  display: flex;
+  flex-direction: column;
+  padding: 50px 20px;
+  gap: 30px;
+}
+li {
+  width: 100%;
+}
+li a {
+  display: inline-block;
+  font-size: 20px;
+  padding: 20px 0;
+  font-weight: 600;
+}
+.router-link-active {
+  @apply text-[rgb(213,21,100)] dark:text-[#2cd69d];
+}
+
+@media (max-width: 1024px) {
+  nav {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+    background: rgba(255, 255, 255, 0.8);
+    z-index: 20;
+    justify-content: center;
+    align-items: center;
+    @apply dark:bg-[rgba(0,0,0,0.8)];
+  }
+  nav.active {
+    display: flex;
+  }
+  ul {
+    padding: 0;
+    gap: 5px;
+    display: block;
+  }
+}
+</style>

--- a/src/stores/isMobileNav.js
+++ b/src/stores/isMobileNav.js
@@ -1,0 +1,11 @@
+import { ref } from 'vue';
+import { defineStore } from 'pinia';
+
+export const useOnMobileNav = defineStore('mobileNav', () => {
+  const isMobileNav = ref(false);
+  const setNav = () => {
+    isMobileNav.value = !isMobileNav.value;
+  };
+
+  return { isMobileNav, setNav };
+});

--- a/src/stores/windowSize.js
+++ b/src/stores/windowSize.js
@@ -1,0 +1,14 @@
+import { ref } from 'vue';
+import { defineStore } from 'pinia';
+
+export const useResponsive = defineStore('responsive', () => {
+  const isMobile = ref(false);
+ 
+  const setMobile = () => {
+    isMobile.value = true;
+  };
+  const setPc = () => {
+    isMobile.value = false;
+  };
+  return { isMobile, setMobile,setPc };
+});


### PR DESCRIPTION
### windowSize.js의 역할
윈도우 창 크기에 따라 모바일 해상도인지 pc 해상도인지 판별합니다.

✅ isMobile
- true: mobile 해상도
- false: pc 해상도

#### App.vue
컴포넌트가 마운트 된 상태에서 window.resize event(창크기 늘이고 줄이는)가 일어났을 때 1024 미만이면 모바일로, 그 이상이면 pc인것으로 값을 변경합니다.

그리고 만약 pc 사이즈로 창크기가 늘어났는데, mobile 버전의 네비게이션이 `true`라면 `false`로 변환 시켜줍니다.

> mobile 버전의 네비게이션이 `true`라면 `false`로 변환: mobile 버전에서 네비게이션이 true 상태로 창을 늘였다가 다시 줄이면, 계속 true인 상태로 네비게이션이 켜져있기 때문에, 창크기 변환이 있을 경우에는 모바일용 네비게이션이 아예 꺼지도록 설정했습니다.

```javascript
onMounted(() => {
  window.addEventListener('resize', () => {
    if (window.innerWidth < 1024) {
      responsive.setMobile();
    } else {
      responsive.setPc();
      if (nav.isMobileNav) {
        nav.setNav();
      }
    }
  });
});
```

### isMobileNav.js의 역할
mobile 버전에서 네비게이션 삼단바 버튼을 클릭 했을 경우 on/off 기능을 담당해줍니다.

⬇️ 아래 버튼을 눌렀을때 on/off가 된다.
![image](https://github.com/Jiyun-Parkk/woorifisa-fe-tech-seminar/assets/72537762/a466815e-d406-4d18-88f8-3f9efe582902)

#### 구현방법
네비게이션 관련 컴포넌트의 스타일 하단을 보면 아래와 같은 코드들이 있습니다. css의 미디어쿼리라는 기능으로 반응형 구현을 할 수 있는데 1024 해상도가 되면 모바일 버전의 네비게이션 버튼이 활성화 되고, 네비게이션 리스트는 눈에 보이지 않게 됩니다.

```css
@media (max-width: 1024px) {
  .btn-wrapper {
    display: block;
  }
}
```
`MobileNavButton`을 클릭하면 isMobileNav의 `setNav()`함수를 호출합니다.

`setNav()`함수를 호출하면, `useOnMobileNav`의 `isMobileNav`상태값에 따라 Navigation 컴포넌트의 렌더링을 해줍니다.

` Navigation 컴포넌트`는 아래코드와 같이 `isMobileNav`가 true 이면 active 클래스를 추가해주고, false면 active 클래스를 삭제합니다.

```html
 <nav
    :class="{ active: nav.isMobileNav }"
    class="border-r-[1px] border-black dark:border-white"
  >
    <ul>
      <li @click="handleSetNav" v-for="nav in navList" :key="nav.id">
        <router-link :to="nav.link">{{ nav.title }}</router-link>
      </li>
    </ul>
  </nav>
```

active 클래스가 붙은 nav는 css에서 아래와 같이 설정해주고 있어서, active 여부에 따라 navigation이 노출됩니다.

```css
  nav.active {
    display: flex;
  }
```